### PR TITLE
Either print error messages or raise exceptions, not both

### DIFF
--- a/DQTools/dataset.py
+++ b/DQTools/dataset.py
@@ -351,9 +351,10 @@ Data:
                                   "pointer.\n%s" % e)
                 print_msg = ("Failed to retrieve Dataset sub-product DASK pointer, ",
                             "please see logfile for details.")
-            print (print_msg)
             if self.raise_exceptions:
                 raise Exception(print_msg) from None
+            else:
+                print (print_msg)
 
     def put(self, tile=None):
         """
@@ -413,9 +414,10 @@ Data:
         except Exception as e:
             msg = "Failed to write data to the datacube."
             self.logger.error(f"{msg}.\n{str(e)}")
-            print(msg)
             if self.raise_exceptions:
                 raise Exception(msg) from None
+            else:
+                print(msg)
 
     def update(self, script, params=None):
         """
@@ -446,9 +448,10 @@ Data:
             self.logger.error("Failed to update the Dataset from script %s.\n"
                               "%s" % (e, script))
             msg = "Failed to update the Dataset from script %s" % script
-            print(msg)
             if self.raise_exceptions:
                 raise Exception(msg) from None
+            else:
+                print(msg)
 
     def calculate_timesteps(self):
         """

--- a/DQTools/dataset.py
+++ b/DQTools/dataset.py
@@ -66,6 +66,15 @@ class Dataset:
 
         :param sysfile: location of the deployed system's yaml file. Required
                         for DASK use.
+
+        :param raise_exceptions: This controls behaviour when an error occurs 
+                        during a subsequent call to get_data, put or update. 
+                        If True: 
+                            an exception of type Exception will be raised, 
+                            whose text describes the error.
+                        If False:
+                            No exception is raised, the error message is 
+                            printed to stdout.
         """
 
         # write product & sub-product as attributes


### PR DESCRIPTION
CMFM  currently prints a spurious  error message the first time data is put to the datacube for a given tile x subproduct.
This is becuase set_last_gold wasn't set.
CMFM handles this by catching an exception and then calling set_last_gold before putting again.

From now on, if raise exceptions is true, don't print the messages.