### PR TITLE
remove old credentials

### DIFF
--- a/DQTools/connect/.assimila_dq
+++ b/DQTools/connect/.assimila_dq
@@ -1,6 +1,0 @@
-{
-    "url"   : "http://35.242.129.254",
-    "port"  : "8081",
-    "pwd"   : "gAAAAABfZMzuJ_UbnSEa2mrTlWmv4ADP39ePMne0C4pyKkbCIzOIpgwrBFgYS0I6rqKQUETcEfU6i9etifYWYlX_0AQR4F470Q==",
-    "login" : "dqtools@assimila.eu"
-}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # DQTools
+
 Tools for working with the DataCube. Includes reading metadata, registering new products and writing new data to the Datacube.
 
 There are two branches:
 
-**'release'** contains the latest tested code which works with the 
-released 
-DataCube code used on the publicly available server. It will have 
-tagged releases 
-and users are strongly advised to download and use the latest release.
+`release` contains the latest tested code which works with the released DataCube code used on the publicly available server. 
+It will have tagged releases and users are strongly advised to download and use the latest release.
   
-**'devel'** contains development code not suitable for use with the publicly available DataCube server.
+`devel` contains development code not suitable for use with the publicly available DataCube server.
 
+## Credentials
+
+In order to authenticate with a DataCube server you must provide a "security identity file".
+This file, provided by Assimila, should be placed within the DQTools source code at `DQTools/connect/.assimila_dq`.
+Alternately, the file path can be specified to the client module if the key file lives elsewhere on the user's system or has a different name.


### PR DESCRIPTION
The datacube credentials that were packaged with DQTools were (a) wrong IP (b) encrypted with a leaked encryption key.
This PR removes the old credentials from git.
User must provide their credentials in order to use DQTools